### PR TITLE
v1.1. Support for multiline links, ctrl-click, right-click

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   editonlink
 author Constant Illumination (Chang Zhao)
 email  alex@obschy.ru
-date   2018-11-16
+date   2018-11-17
 name   Edit On Link
 desc   For inner wiki links it inserts a hover popover button [[...?do=edit]]
 url    https://www.dokuwiki.org/plugin:editonlink

--- a/script.js
+++ b/script.js
@@ -1,12 +1,39 @@
 window.onload=function() {
-    document.body.addEventListener('click', function (event) {
-        var a = event.target || event.srcElement;
-        if (a.tagName === 'A' && (a.classList.contains("wikilink1") || a.classList.contains("wikilink2") || a.classList.contains("breadcrumbs"))) {
-            var xy = a.getBoundingClientRect(),
-                dx = xy.width - event.offsetX,
-                dy = event.offsetY,
-                r = parseFloat(window.getComputedStyle(a, ':after')['height'])/2 + 1;
-            if (dx*dx + dy*dy < r*r) a.href = (a.href.split('#', 1))[0] + '?do=edit';
-        }
-    });
+    document.body.addEventListener('click', editOnLink);
+    document.body.addEventListener('contextmenu', editOnLink);
 };
+function editOnLink(e) {
+    var a = e.target || e.srcElement;
+    if (a.tagName === 'A' && (a.classList.contains("wikilink1") || a.classList.contains("wikilink2") || a.classList.contains("breadcrumbs"))) {
+
+        // In case of multy-line link, simple getBoundingClientRect wouldn't work well,
+        // so we find the spot by adding another element with the same positioning as
+        // that ":after" button. Thus we know where the popover button is.
+        var v = document.createElement('span');
+        v.id = 'plugin__editonlink';
+        a.appendChild(v);
+        var xy = v.getBoundingClientRect(),
+            x = xy.right,
+            y = xy.top,                         // x,y = of the popover button center
+            xya = a.getBoundingClientRect(),    // the mouse click was related to <a>
+            dx = e.offsetX + xya.left - x,      // how far the click was from the button?
+            dy = e.offsetY + xya.top - y,
+            r = parseFloat(window.getComputedStyle(a, ':after')['height'])/2 + 1;
+        if ((dx*dx + dy*dy) < r*r) {
+            a.setAttribute('data-editonlink', a.href);          // maybe ctrl-click etc
+            a.href = (a.href.split(/[?#]/))[0] + '?do=edit';    // add EDIT to the link
+            v.remove();
+            a.addEventListener('mouseleave', editOnLinkOut);    // to restore the link back
+        }
+    }
+}
+function editOnLinkOut(e) {
+    var a = e.target || e.srcElement;
+    if (a.tagName !== 'A') return;
+    var d = a.getAttribute('data-editonlink');
+    if (d) {
+        a.href = d;
+        a.removeAttribute('data-editonlink');
+    }
+    a.removeEventListener('mouseleave');
+}

--- a/style.css
+++ b/style.css
@@ -35,3 +35,13 @@ a.wikilink1:hover:after, a.wikilink2:hover:after, a.breadcrumbs:hover:after {
     opacity: 0.9;
     margin: -0.6em -0.6em 0 0;
 }
+span#plugin__editonlink {
+    position: absolute;
+    top: 0;
+    right: 0;
+    background-color: #FFF;
+    border: thin solid #666;
+    color: #333;
+    z-index: 101;
+    opacity: 0;
+}

--- a/test.php
+++ b/test.php
@@ -19,8 +19,8 @@ decoration and a popover button.</p>
 <div><a href="test.php" class="wikilink1">LINK TO TEST.PHP</a></div>
 <p>Clicking that button must turn URL<br>
 "test.php" into "test.php?do=edit".</p>
-<p> <a href="test.php" class="breadcrumbs" style="font-size: x-small">breadcrumbs</a> *
-    <a href="test.php#" class="breadcrumbs" style="font-size: small">breadcrumbs</a> *
-    <a href="test.php" class="wikilink2" style="font-size: large; color: red;">wikilink2</a></p>
+<p> <a href="test.php#top" class="breadcrumbs" style="font-size: x-small">breadcrumbs</a> *
+    <a href="test.php?do=oops" class="breadcrumbs" style="font-size: small">breadcrumbs</a> *
+    <a href="test.php?do=oops#top" class="wikilink2" style="font-size: large; color: red;">wikilink2</a></p>
 </body>
 </html>


### PR DESCRIPTION
In case of multiline link, clientBoundingRect top-right might not give the correct position of the button; so I use adding another element with the same positioning on the link click, to learn the actual position.
As for ctrl-click and right-click, the user can stay on the page, so i restore the target link to its original href (onmouseleave).